### PR TITLE
Stop copy the .env to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN chown -R node:node /usr/src/node-app
 
 USER node
 
-COPY package.json yarn.lock .env ./
+COPY package.json yarn.lock ./
 
 RUN yarn install
 


### PR DESCRIPTION
Now we are passing environment variables to the docker container, not to
the docker image. This is because they are all runtime variables and we
can redeploy the application without additional re-build.