### PR TITLE
Make env.js file path absolute, because of wrong download path when opening not a starting page in the browser

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -76,7 +76,7 @@
     integrity="sha384-aBAQ/XaGQ46JI8ZFiU1HCW1W6Thed0TvHM8Yn2OK8+qEYpOnCOmiRAo3hAfufpaE"
     crossorigin="anonymous"
   />
-  <script src="env.js"></script>
+  <script src="/env.js"></script>
 </head>
 
 <body id="page-top" data-spy="scroll" data-target=".navbar-fixed-top">


### PR DESCRIPTION
A wrong path is used for downloading the env.js script, when the human app is opened(or refreshed) not from the main page. For example - "https://app.humanprotocol.org/workspace" will lead to downloading the "https://app.humanprotocol.org/workspace/env.js"